### PR TITLE
feat/canvas ports

### DIFF
--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasAssignmentGroupRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasAssignmentGroupRepository.java
@@ -1,0 +1,116 @@
+package com.bestprograteam.canvas_dashboard.model.adapters;
+
+import com.bestprograteam.canvas_dashboard.model.entities.AssignmentGroup;
+import com.bestprograteam.canvas_dashboard.model.repositories.AssignmentGroupRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Primary
+@Repository("canvasAssignmentGroupRepository")
+public class CanvasAssignmentGroupRepository implements AssignmentGroupRepository {
+
+    @Value("${canvas.instance.url}")
+    private String canvasInstanceUrl;
+
+    private final RestTemplate restTemplate;
+
+    public CanvasAssignmentGroupRepository() {
+        this.restTemplate = new RestTemplateBuilder()
+                .readTimeout(Duration.ofSeconds(10))
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    private String getApiToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object details = authentication.getDetails();
+            if (details instanceof Map) {
+                Map<String, Object> userDetails = (Map<String, Object>) details;
+                return (String) userDetails.get("apiToken");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<AssignmentGroup> findAssignmentGroupsByCourseId(Integer courseId) {
+        try {
+            System.out.println("[CanvasAssignmentGroupRepository] Fetching assignment groups for course " + courseId + "...");
+            String apiToken = getApiToken();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + apiToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List> response = restTemplate.exchange(
+                    canvasInstanceUrl + "/api/v1/courses/" + courseId + "/assignment_groups?per_page=100",
+                    HttpMethod.GET,
+                    entity,
+                    List.class
+            );
+            System.out.println("[CanvasAssignmentGroupRepository] Successfully fetched " + (response.getBody() != null ? response.getBody().size() : 0) + " assignment groups for course " + courseId);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Map<String, Object>> groupsData = response.getBody();
+                List<AssignmentGroup> groups = new ArrayList<>();
+
+                for (Map<String, Object> data : groupsData) {
+                    AssignmentGroup group = mapToAssignmentGroup(data, courseId);
+                    if (group != null) {
+                        groups.add(group);
+                    }
+                }
+
+                return groups;
+            }
+        } catch (Exception e) {
+            System.err.println("[CanvasAssignmentGroupRepository] ERROR fetching assignment groups for course " + courseId + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public AssignmentGroup findAssignmentGroupById(Integer courseId, Integer groupId) {
+        List<AssignmentGroup> groups = findAssignmentGroupsByCourseId(courseId);
+        return groups.stream()
+                .filter(g -> g.id.equals(groupId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private AssignmentGroup mapToAssignmentGroup(Map<String, Object> data, Integer courseId) {
+        try {
+            Integer id = (Integer) data.get("id");
+            String name = (String) data.get("name");
+            Integer position = (Integer) data.get("position");
+            Double groupWeight = getDouble(data.get("group_weight"));
+
+            return new AssignmentGroup(id, courseId, name, position, groupWeight);
+        } catch (Exception e) {
+            System.err.println("Error mapping assignment group: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Double getDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Integer) return ((Integer) value).doubleValue();
+        return null;
+    }
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasAssignmentRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasAssignmentRepository.java
@@ -1,0 +1,143 @@
+package com.bestprograteam.canvas_dashboard.model.adapters;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Assignment;
+import com.bestprograteam.canvas_dashboard.model.repositories.AssignmentRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Primary
+@Repository("canvasAssignmentRepository")
+public class CanvasAssignmentRepository implements AssignmentRepository {
+
+    @Value("${canvas.instance.url}")
+    private String canvasInstanceUrl;
+
+    private final RestTemplate restTemplate;
+
+    public CanvasAssignmentRepository() {
+        this.restTemplate = new RestTemplateBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .readTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    private String getApiToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object details = authentication.getDetails();
+            if (details instanceof Map) {
+                Map<String, Object> userDetails = (Map<String, Object>) details;
+                return (String) userDetails.get("apiToken");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Assignment> findAssignmentsByCourseId(Integer courseId) {
+        try {
+            System.out.println("[CanvasAssignmentRepository] Fetching assignments for course " + courseId + "...");
+            String apiToken = getApiToken();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + apiToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List> response = restTemplate.exchange(
+                    canvasInstanceUrl + "/api/v1/courses/" + courseId + "/assignments?per_page=100",
+                    HttpMethod.GET,
+                    entity,
+                    List.class
+            );
+            System.out.println("[CanvasAssignmentRepository] Successfully fetched " + (response.getBody() != null ? response.getBody().size() : 0) + " assignments for course " + courseId);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Map<String, Object>> assignmentsData = response.getBody();
+                List<Assignment> assignments = new ArrayList<>();
+
+                for (Map<String, Object> data : assignmentsData) {
+                    Assignment assignment = mapToAssignment(data, courseId);
+                    if (assignment != null) {
+                        assignments.add(assignment);
+                    }
+                }
+
+                return assignments;
+            }
+        } catch (Exception e) {
+            System.err.println("[CanvasAssignmentRepository] ERROR fetching assignments for course " + courseId + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Assignment findAssignmentById(Integer courseId, Integer assignmentId) {
+        List<Assignment> assignments = findAssignmentsByCourseId(courseId);
+        return assignments.stream()
+                .filter(a -> a.id.equals(assignmentId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public List<Assignment> findUpcomingAssignments(Integer courseId, Integer days) {
+        List<Assignment> assignments = findAssignmentsByCourseId(courseId);
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime future = now.plusDays(days);
+
+        return assignments.stream()
+                .filter(a -> a.dueAt != null)
+                .filter(a -> a.dueAt.isAfter(now) && a.dueAt.isBefore(future))
+                .collect(Collectors.toList());
+    }
+
+    private Assignment mapToAssignment(Map<String, Object> data, Integer courseId) {
+        try {
+            Integer id = (Integer) data.get("id");
+            String name = (String) data.get("name");
+            String dueAtStr = (String) data.get("due_at");
+
+            LocalDateTime dueAt = null;
+            if (dueAtStr != null) {
+                try {
+                    dueAt = LocalDateTime.parse(dueAtStr.substring(0, 19));
+                } catch (Exception e) {
+                }
+            }
+
+            Double pointsPossible = getDouble(data.get("points_possible"));
+            Integer assignmentGroupId = (Integer) data.get("assignment_group_id");
+            String workflowState = (String) data.get("workflow_state");
+
+            return new Assignment(id, courseId, name, dueAt, pointsPossible,
+                    assignmentGroupId, workflowState);
+        } catch (Exception e) {
+            System.err.println("Error mapping assignment: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Double getDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Integer) return ((Integer) value).doubleValue();
+        return null;
+    }
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasCourseRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasCourseRepository.java
@@ -1,0 +1,108 @@
+package com.bestprograteam.canvas_dashboard.model.adapters;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Course;
+import com.bestprograteam.canvas_dashboard.model.repositories.CourseRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Primary
+@Repository("canvasCourseRepository")
+public class CanvasCourseRepository implements CourseRepository {
+
+    @Value("${canvas.instance.url}")
+    private String canvasInstanceUrl;
+
+    private final RestTemplate restTemplate;
+
+    public CanvasCourseRepository() {
+        this.restTemplate = new RestTemplateBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .readTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    private String getApiToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object details = authentication.getDetails();
+            if (details instanceof Map) {
+                Map<String, Object> userDetails = (Map<String, Object>) details;
+                return (String) userDetails.get("apiToken");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Course> findAllActiveCourses() {
+        try {
+            System.out.println("[CanvasCourseRepository] Fetching courses from Canvas API...");
+            String apiToken = getApiToken();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + apiToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List> response = restTemplate.exchange(
+                    canvasInstanceUrl + "/api/v1/courses?enrollment_state=active&per_page=100",
+                    HttpMethod.GET,
+                    entity,
+                    List.class
+            );
+            System.out.println("[CanvasCourseRepository] Successfully fetched " + (response.getBody() != null ? response.getBody().size() : 0) + " courses");
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Map<String, Object>> coursesData = response.getBody();
+                List<Course> courses = new ArrayList<>();
+
+                for (Map<String, Object> data : coursesData) {
+                    Course course = mapToCourse(data);
+                    if (course != null) {
+                        courses.add(course);
+                    }
+                }
+
+                return courses;
+            }
+        } catch (Exception e) {
+            System.err.println("[CanvasCourseRepository] ERROR fetching courses: " + e.getMessage());
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+
+    private Course mapToCourse(Map<String, Object> data) {
+        try {
+            String id = String.valueOf(data.get("id"));
+            String name = (String) data.get("name");
+            String courseCode = (String) data.get("course_code");
+            String workflowState = (String) data.get("workflow_state");
+
+            String enrollmentType = "StudentEnrollment";
+            Date startDate = new Date(System.currentTimeMillis() - 90L * 24 * 60 * 60 * 1000);
+            Date endDate = new Date(System.currentTimeMillis() + 90L * 24 * 60 * 60 * 1000);
+            float totalPoints = 0f;
+            float currentGrade = 0f;
+
+            return new Course(id, name, courseCode, workflowState, enrollmentType,
+                    startDate, endDate, totalPoints, currentGrade);
+        } catch (Exception e) {
+            System.err.println("Error mapping course: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasEnrollmentRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasEnrollmentRepository.java
@@ -1,0 +1,138 @@
+package com.bestprograteam.canvas_dashboard.model.adapters;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Enrollment;
+import com.bestprograteam.canvas_dashboard.model.repositories.EnrollmentRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Primary
+@Repository("canvasEnrollmentRepository")
+public class CanvasEnrollmentRepository implements EnrollmentRepository {
+
+    @Value("${canvas.instance.url}")
+    private String canvasInstanceUrl;
+
+    private final RestTemplate restTemplate;
+
+    public CanvasEnrollmentRepository() {
+        this.restTemplate = new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofSeconds(10))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    private String getApiToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object details = authentication.getDetails();
+            if (details instanceof Map) {
+                Map<String, Object> userDetails = (Map<String, Object>) details;
+                return (String) userDetails.get("apiToken");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Enrollment> findAllEnrollments() {
+        try {
+            System.out.println("[CanvasEnrollmentRepository] Fetching enrollments from Canvas API...");
+            String apiToken = getApiToken();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + apiToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List> response = restTemplate.exchange(
+                    canvasInstanceUrl + "/api/v1/users/self/enrollments?per_page=100",
+                    HttpMethod.GET,
+                    entity,
+                    List.class
+            );
+            System.out.println("[CanvasEnrollmentRepository] Successfully fetched " + (response.getBody() != null ? response.getBody().size() : 0) + " enrollments");
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Map<String, Object>> enrollmentsData = response.getBody();
+                List<Enrollment> enrollments = new ArrayList<>();
+
+                for (Map<String, Object> data : enrollmentsData) {
+                    Enrollment enrollment = mapToEnrollment(data);
+                    if (enrollment != null) {
+                        enrollments.add(enrollment);
+                    }
+                }
+
+                return enrollments;
+            }
+        } catch (Exception e) {
+            System.err.println("[CanvasEnrollmentRepository] ERROR fetching enrollments: " + e.getMessage());
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Enrollment findEnrollmentByCourseId(Integer courseId) {
+        List<Enrollment> enrollments = findAllEnrollments();
+        return enrollments.stream()
+                .filter(e -> e.courseId.equals(courseId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Enrollment mapToEnrollment(Map<String, Object> data) {
+        try {
+            Map<String, Object> grades = (Map<String, Object>) data.get("grades");
+
+            Integer courseId = (Integer) data.get("course_id");
+            String enrollmentState = (String) data.get("enrollment_state");
+
+            Double currentScore = grades != null ? getDouble(grades.get("current_score")) : null;
+            Double finalScore = grades != null ? getDouble(grades.get("final_score")) : null;
+            String currentGrade = grades != null ? (String) grades.get("current_grade") : null;
+
+            String lastActivityAtStr = (String) data.get("last_activity_at");
+            LocalDateTime lastActivityAt = lastActivityAtStr != null
+                    ? LocalDateTime.parse(lastActivityAtStr.substring(0, 19))
+                    : null;
+
+            Integer totalActivityTime = (Integer) data.get("total_activity_time");
+
+            return new Enrollment(courseId, enrollmentState, currentScore, finalScore,
+                    currentGrade, lastActivityAt, totalActivityTime);
+        } catch (Exception e) {
+            System.err.println("Error mapping enrollment: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Double getDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Integer) return ((Integer) value).doubleValue();
+        if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasSubmissionRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/adapters/CanvasSubmissionRepository.java
@@ -1,0 +1,139 @@
+package com.bestprograteam.canvas_dashboard.model.adapters;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Submission;
+import com.bestprograteam.canvas_dashboard.model.repositories.SubmissionRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Primary
+@Repository("canvasSubmissionRepository")
+public class CanvasSubmissionRepository implements SubmissionRepository {
+
+    @Value("${canvas.instance.url}")
+    private String canvasInstanceUrl;
+
+    private final RestTemplate restTemplate;
+
+    public CanvasSubmissionRepository() {
+        this.restTemplate = new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofSeconds(10))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    private String getApiToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object details = authentication.getDetails();
+            if (details instanceof Map) {
+                Map<String, Object> userDetails = (Map<String, Object>) details;
+                return (String) userDetails.get("apiToken");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Submission> findSubmissionsByCourseId(Integer courseId) {
+        try {
+            System.out.println("[CanvasSubmissionRepository] Fetching submissions for course " + courseId + "...");
+            String apiToken = getApiToken();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + apiToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List> response = restTemplate.exchange(
+                    canvasInstanceUrl + "/api/v1/courses/" + courseId + "/students/submissions?student_id=self&per_page=100",
+                    HttpMethod.GET,
+                    entity,
+                    List.class
+            );
+            System.out.println("[CanvasSubmissionRepository] Successfully fetched " + (response.getBody() != null ? response.getBody().size() : 0) + " submissions for course " + courseId);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Map<String, Object>> submissionsData = response.getBody();
+                List<Submission> submissions = new ArrayList<>();
+
+                for (Map<String, Object> data : submissionsData) {
+                    Submission submission = mapToSubmission(data);
+                    if (submission != null) {
+                        submissions.add(submission);
+                    }
+                }
+
+                return submissions;
+            }
+        } catch (Exception e) {
+            System.err.println("[CanvasSubmissionRepository] ERROR fetching submissions for course " + courseId + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Submission findSubmissionByAssignmentId(Integer courseId, Integer assignmentId) {
+        List<Submission> submissions = findSubmissionsByCourseId(courseId);
+        return submissions.stream()
+                .filter(s -> s.assignmentId.equals(assignmentId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public List<Submission> findRecentGrades(Integer courseId, Integer limit) {
+        List<Submission> submissions = findSubmissionsByCourseId(courseId);
+        return submissions.stream()
+                .filter(s -> s.gradedAt != null)
+                .sorted(Comparator.comparing((Submission s) -> s.gradedAt).reversed())
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    private Submission mapToSubmission(Map<String, Object> data) {
+        try {
+            Integer assignmentId = (Integer) data.get("assignment_id");
+            Double score = getDouble(data.get("score"));
+            String workflowState = (String) data.get("workflow_state");
+
+            String gradedAtStr = (String) data.get("graded_at");
+            LocalDateTime gradedAt = null;
+            if (gradedAtStr != null) {
+                try {
+                    gradedAt = LocalDateTime.parse(gradedAtStr.substring(0, 19));
+                } catch (Exception e) {
+                }
+            }
+
+            Boolean late = (Boolean) data.get("late");
+
+            return new Submission(assignmentId, score, workflowState, gradedAt, late);
+        } catch (Exception e) {
+            System.err.println("Error mapping submission: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Double getDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof Double) return (Double) value;
+        if (value instanceof Integer) return ((Integer) value).doubleValue();
+        return null;
+    }
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/AssignmentGroupRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/AssignmentGroupRepository.java
@@ -1,0 +1,26 @@
+package com.bestprograteam.canvas_dashboard.model.repositories;
+
+import com.bestprograteam.canvas_dashboard.model.entities.AssignmentGroup;
+import java.util.List;
+
+/**
+ * Repository interface for AssignmentGroup entity.
+ * Provides access to grade category information for weighted grade calculations.
+ */
+public interface AssignmentGroupRepository {
+
+    /**
+     * Get all assignment groups (grade categories) for a course.
+     * @param courseId Canvas course ID
+     * @return List of assignment groups with weights
+     */
+    List<AssignmentGroup> findAssignmentGroupsByCourseId(Integer courseId);
+
+    /**
+     * Get a specific assignment group by ID.
+     * @param courseId Canvas course ID
+     * @param groupId Canvas assignment group ID
+     * @return AssignmentGroup or null if not found
+     */
+    AssignmentGroup findAssignmentGroupById(Integer courseId, Integer groupId);
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/AssignmentRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/AssignmentRepository.java
@@ -1,0 +1,34 @@
+package com.bestprograteam.canvas_dashboard.model.repositories;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Assignment;
+import java.util.List;
+
+/**
+ * Repository interface for Assignment entity.
+ * Provides access to assignment data for due dates and points calculations.
+ */
+public interface AssignmentRepository {
+
+    /**
+     * Get all assignments for a course.
+     * @param courseId Canvas course ID
+     * @return List of assignments
+     */
+    List<Assignment> findAssignmentsByCourseId(Integer courseId);
+
+    /**
+     * Get a specific assignment by ID.
+     * @param courseId Canvas course ID
+     * @param assignmentId Canvas assignment ID
+     * @return Assignment or null if not found
+     */
+    Assignment findAssignmentById(Integer courseId, Integer assignmentId);
+
+    /**
+     * Get assignments due within the next N days for a course.
+     * @param courseId Canvas course ID
+     * @param days Number of days to look ahead
+     * @return List of upcoming assignments
+     */
+    List<Assignment> findUpcomingAssignments(Integer courseId, Integer days);
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/CourseRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/CourseRepository.java
@@ -1,0 +1,17 @@
+package com.bestprograteam.canvas_dashboard.model.repositories;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Course;
+import java.util.List;
+
+/**
+ * Repository interface for Course entity.
+ * Implementations will fetch course data from Canvas API or mock data sources.
+ */
+public interface CourseRepository {
+
+    /**
+     * Get all active courses for the current authenticated student.
+     * @return List of courses with enrollment_state=active
+     */
+    List<Course> findAllActiveCourses();
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/EnrollmentRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/EnrollmentRepository.java
@@ -1,0 +1,26 @@
+package com.bestprograteam.canvas_dashboard.model.repositories;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Enrollment;
+import java.util.List;
+
+/**
+ * Repository interface for Enrollment entity.
+ * Provides access to Canvas-computed grades and enrollment information.
+ * This is the MOST IMPORTANT repository as it gets all course grades in one API call.
+ */
+public interface EnrollmentRepository {
+
+    /**
+     * Get all active enrollments for the current student.
+     * Includes Canvas-computed grades (current_score, final_score).
+     * @return List of enrollments with grades
+     */
+    List<Enrollment> findAllEnrollments();
+
+    /**
+     * Get enrollment (with grades) for a specific course.
+     * @param courseId Canvas course ID
+     * @return Enrollment or null if not found
+     */
+    Enrollment findEnrollmentByCourseId(Integer courseId);
+}

--- a/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/SubmissionRepository.java
+++ b/src/main/java/com/bestprograteam/canvas_dashboard/model/repositories/SubmissionRepository.java
@@ -1,0 +1,35 @@
+package com.bestprograteam.canvas_dashboard.model.repositories;
+
+import com.bestprograteam.canvas_dashboard.model.entities.Submission;
+import java.util.List;
+
+/**
+ * Repository interface for Submission entity.
+ * Provides access to student submission data for grade calculations and trends.
+ */
+public interface SubmissionRepository {
+
+    /**
+     * Get all submissions (including unsubmitted) for current student in a course.
+     * @param courseId Canvas course ID
+     * @return List of submissions
+     */
+    List<Submission> findSubmissionsByCourseId(Integer courseId);
+
+    /**
+     * Get a specific submission by assignment ID.
+     * @param courseId Canvas course ID
+     * @param assignmentId Canvas assignment ID
+     * @return Submission or null if not found
+     */
+    Submission findSubmissionByAssignmentId(Integer courseId, Integer assignmentId);
+
+    /**
+     * Get the N most recent graded submissions for a course.
+     * Sorted by graded_at DESC.
+     * @param courseId Canvas course ID
+     * @param limit Number of recent grades to return
+     * @return List of recent submissions
+     */
+    List<Submission> findRecentGrades(Integer courseId, Integer limit);
+}


### PR DESCRIPTION
## Add Canvas API Repository Adapters for Core Entities

### Summary
This PR implements repository adapters that connect our application to the Canvas LMS API, enabling real-time data fetching for courses, assignments, enrollments, submissions, and assignment groups.

### Changes

#### New Repository Interfaces
- `CourseRepository` - Fetch active courses for authenticated students
- `AssignmentRepository` - Access assignment data, due dates, and points
- `EnrollmentRepository` - Retrieve Canvas-computed grades and enrollment info
- `SubmissionRepository` - Get student submission data and grade history  
- `AssignmentGroupRepository` - Access grade categories for weighted calculations

#### Canvas API Adapter Implementations
- `CanvasCourseRepository` - Fetches active courses via `/api/v1/courses`
- `CanvasAssignmentRepository` - Retrieves assignments with due dates and points
- `CanvasEnrollmentRepository` - Gets enrollments with Canvas-computed grades (current_score, final_score)
- `CanvasSubmissionRepository` - Fetches submission data including scores and late status
- `CanvasAssignmentGroupRepository` - Retrieves assignment groups with weighting info

### Technical Details
- All adapters use Spring's `RestTemplate` with 10-second timeouts
- Authentication via Bearer token extracted from Spring Security context
- `@Primary` annotations ensure Canvas adapters are default implementations
- Pagination support with `per_page=100` parameter
- Comprehensive error handling and logging for debugging

### Key Features
- **Upcoming assignments**: Find assignments due within N days
- **Recent grades**: Retrieve most recently graded submissions
- **Grade calculations**: Support for weighted grade categories
- **Activity tracking**: Last activity timestamps and total time spent

### Configuration
Requires `canvas.instance.url` property to be set in application configuration.